### PR TITLE
Fix building FNA on Linux

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -64,6 +64,8 @@ jobs:
     - name: Install Git and cURL (Linux)
       if: ${{ matrix.platform == 'linux' }}
       run: |
+        # Debian buster is now EOL, need to set APT to use the package archive.
+        sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
         apt-get update
         apt-get install -y git curl ca-certificates
 
@@ -142,7 +144,7 @@ jobs:
         # Setup Debian Bullseye PPA for newer CMake and Wayland version
         echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
         echo "deb http://security.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
-        echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+        echo "deb http://archive.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
         cat <<EOF > /etc/apt/preferences.d/bullseye
         Package: *
         Pin: release n=bullseye


### PR DESCRIPTION
CI was broken due to debian buster being EOL'd, resulting in the package repositories apt relies on to 404.

We fix this by replacing deb.debian.org with archive.debian.org in the apt sources.list.